### PR TITLE
Removed `SkyThemeService` from filter module providers

### DIFF
--- a/projects/lists/src/modules/filter/filter-button.component.ts
+++ b/projects/lists/src/modules/filter/filter-button.component.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   Input,
   OnInit,
+  Optional,
   Output
 } from '@angular/core';
 
@@ -79,13 +80,13 @@ export class SkyFilterButtonComponent implements OnInit {
   private _filterButtonId: string;
 
   constructor(
-    public themeSvc: SkyThemeService,
+    @Optional() public themeSvc: SkyThemeService,
     private changeDetector: ChangeDetectorRef
   ) {
   }
 
   public ngOnInit(): void {
-    this.themeSvc.settingsChange.subscribe(() => {
+    this.themeSvc?.settingsChange.subscribe(() => {
       // Push changes b/c SkyIconComponent uses ChangeDetectionStrategy.OnPush
       this.changeDetector.markForCheck();
     });

--- a/projects/lists/src/modules/filter/filter.module.ts
+++ b/projects/lists/src/modules/filter/filter.module.ts
@@ -12,8 +12,7 @@ import {
 } from '@skyux/indicators';
 
 import {
-  SkyThemeModule,
-  SkyThemeService
+  SkyThemeModule
 } from '@skyux/theme';
 
 import {
@@ -61,9 +60,6 @@ import {
     SkyFilterInlineItemComponent,
     SkyFilterSummaryComponent,
     SkyFilterSummaryItemComponent
-  ],
-  providers: [
-    SkyThemeService
   ]
 })
 export class SkyFilterModule { }


### PR DESCRIPTION
This was overriding the root injector's theme service when imported into a lazy-loaded module.